### PR TITLE
unicornの自動起動処理を追加

### DIFF
--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -11,3 +11,4 @@
     - { role: database, tags: database }
     - { role: yarn, tags: yarn, become: yes }
     - { role: webpacker, tags: webpacker }
+    - { role: autostart_unicorn, tags: autostart_unicorn }

--- a/ansible/roles/autostart_unicorn/tasks/main.yml
+++ b/ansible/roles/autostart_unicorn/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: unicorn.servise -> /etc/systemd/system
+  become: yes
+  template:
+    src: roles/autostart_unicorn/templates/unicorn.servise.j2 
+    dest: /etc/systemd/system/unicorn.service
+
+- name: Autostart unicorn
+  become: yes
+  shell: bash -lc "systemctl enable unicorn.service"
+
+# unicornの自動起動設定後にunicornを起動したいため、サーバ再起動TASKを別途組み込む
+# - name: Start unicorn
+#   shell: bash -lc "bundle exec unicorn_rails -c config/unicorn.rb -E production"

--- a/ansible/roles/autostart_unicorn/templates/unicorn.servise.j2
+++ b/ansible/roles/autostart_unicorn/templates/unicorn.servise.j2
@@ -1,0 +1,39 @@
+[Unit]
+#ユニットの説明
+Description=The unicorn process
+#設定するユニットの後に起動するユニット
+Before=nginx.service
+#設定するユニットの前に起動するユニット
+After=network.target remote-fs.target
+
+[Service]
+#実行時のユーザ
+User=ec2-user
+#作業ディレクトリの指定
+WorkingDirectory=/var/www/raisetech-live8-sample-app
+#標準出力先をsyslogに設定
+StandardOutput = syslog
+#標準エラー出力先をsyslogに設定
+StandardError = syslog
+#PIDファイルのフルパス
+PIDFile=/var/www/raisetech-live8-sample-app/tmp/unicorn.pid
+#syslogへ出力する際の識別子を設定
+SyslogIdentifier = unicorn
+#サービスの起動完了を判定するタイミングを指定。指定コマンドがフォアグラウンドで実行を継続する場合。コマンドを実行したらすぐに起動完了と判定。
+Type=simple
+#プロセスが異常終了した場合にサービス再起動する
+Restart=always
+#変数
+Environment=RAILS_ENV=production
+#変数
+Environment=UNICORN_CONF=/var/www/raisetech-live8-sample-app/config/unicorn.rb
+#unicornの起動　※　-lはログイン状態のシェルで-cは引数のコマンドを実行するという意味
+ExecStart=/bin/bash -l -c 'bundle exec unicorn_rails -c ${UNICORN_CONF} -E ${RAILS_ENV} -D'
+#unicornの停止
+ExecStop=/usr/bin/kill -QUIT $MAINPID
+#unicornの再起動
+ExecReload=/usr/bin/kill -USR2 $MAINPID
+
+[Install]
+#enable時にこのUnitの.wantsディレクトリにシンボリックリンクをはる
+WantedBy=multi-user.target

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -20,5 +20,12 @@
     src: roles/nginx/templates/raisetech-live8-sample-app.conf.j2
     dest: /etc/nginx/conf.d/raisetech-live8-sample-app.conf
 
+# default.confの拡張子を変更
+- name: Move default.conf default.conf.backup
+  command: mv /etc/nginx/conf.d/raisetech-live8-sample-app.conf /etc/nginx/conf.d/raisetech-live8-sample-app.conf.backup
+
 - name: Auto start Nginx
   shell: bash -lc "systemctl enable nginx.service"
+
+- name: Restart Nginx
+  shell: bash -lc "sudo systemctl restart nginx.service"


### PR DESCRIPTION
### 概要
* /etc/systemd/system/unicorn.serviceを作成し、以下を記述

```
[Unit]
#ユニットの説明
Description=The unicorn process
#設定するユニットの後に起動するユニット
Before=nginx.service
#設定するユニットの前に起動するユニット
After=network.target remote-fs.target

[Service]
#実行時のユーザ
User=ec2-user
#作業ディレクトリの指定
WorkingDirectory=/var/www/raisetech-live8-sample-app
#標準出力先をsyslogに設定
StandardOutput = syslog
#標準エラー出力先をsyslogに設定
StandardError = syslog
#PIDファイルのフルパス
PIDFile=/var/www/raisetech-live8-sample-app/tmp/unicorn.pid
#syslogへ出力する際の識別子を設定
SyslogIdentifier = unicorn
#サービスの起動完了を判定するタイミングを指定。指定コマンドがフォアグラウンドで実行を継続する場合。コマンドを実行したらすぐに起動完了と判定。
Type=simple
#プロセスが異常終了した場合にサービス再起動する
Restart=always
#変数
Environment=RAILS_ENV=production
#変数
Environment=UNICORN_CONF=/var/www/raisetech-live8-sample-app/config/unicorn.rb
#unicornの起動　※　-lはログイン状態のシェルで-cは引数のコマンドを実行するという意味
ExecStart=/bin/bash -l -c 'bundle exec unicorn_rails -c ${UNICORN_CONF} -E ${RAILS_ENV} -D'
#unicornの停止
ExecStop=/usr/bin/kill -QUIT $MAINPID
#unicornの再起動
ExecReload=/usr/bin/kill -USR2 $MAINPID

[Install]
#enable時にこのUnitの.wantsディレクトリにシンボリックリンクをはる
WantedBy=multi-user.target
```

* 自動起動を下記コマンドで有効化
`systemctl enable unicorn.service`