### PR TITLE
/etc/nginx/conf.d配下の設定ファイルの記述を修正

### DIFF
--- a/ansible/roles/nginx/templates/raisetech-live8-sample-app.conf.j2
+++ b/ansible/roles/nginx/templates/raisetech-live8-sample-app.conf.j2
@@ -11,13 +11,14 @@ server {
   access_log /var/log/nginx/access.log;
   error_log /var/log/nginx/error.log;
   root /var/www/raisetech-live8-sample-app/public;
+  try_files $uri/index.html $uri @unicorn; #追記
 
   location ^~ /assets/ {
     gzip_static on;
     add_header Cache-Control public;
   }
 
-  try_files $uri/index.html $uri @unicorn;
+  #try_files $uri/index.html $uri @unicorn; #コメントアウト
 
   location @unicorn {
     proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;


### PR DESCRIPTION
### 概要
下記参照
```
client_max_body_size 2G;

upstream unicorn {
  server unix:/var/www/raisetech-live8-sample-app/tmp/unicorn.sock;
}

server {
  listen 80;
  server_name {{ ansible_host }};
  keepalive_timeout 5;
  access_log /var/log/nginx/access.log;
  error_log /var/log/nginx/error.log;
  root /var/www/raisetech-live8-sample-app/public;
  try_files $uri/index.html $uri @unicorn; #追記

  location ^~ /assets/ {
    gzip_static on;
    add_header Cache-Control public;
  }

  #try_files $uri/index.html $uri @unicorn; #コメントアウト

  location @unicorn {
    proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header Host $http_host;
    proxy_redirect off;
    proxy_pass http://unicorn;
  }

  error_page 500 502 503 504 /500.html;
  location = /500.html {
  }

  location = /sitemap.xml.gz {
  }

  location = /robots.txt {
  }

  location = /favicon.ico {
  }
}
```